### PR TITLE
Validation and improved to 'minutes' attribute from the meeting table (Acta)

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -17,13 +17,16 @@
 
 class Meeting < ActiveRecord::Base
 
+  MINUTES_MAX_LENGTH = 20000
+
   has_many :user_meetings
   has_many :users, through: :user_meetings
 
   has_many :meeting_groups
   has_many :groups, through: :meeting_groups
 
-  # validates :group,
-  #   presence: true
+  validates :minutes,
+    presence:   true,
+    length:     { maximum: MINUTES_MAX_LENGTH }
 
 end

--- a/app/views/meetings/_form.html.erb
+++ b/app/views/meetings/_form.html.erb
@@ -92,7 +92,6 @@
               function Editor(input, preview) {
                 this.update = function () {
                   preview.innerHTML = markdown.toHTML(input.value);
-                  // preview.html( markdown.toHTML(input.value() ));
                 };
                 input.editor = this;
                 this.update();
@@ -104,7 +103,7 @@
 
               textArea.on('change keyup paste', function() {
                 $(this).css('height', preview.parent().height());
-              });
+              }).trigger('change');
             </script>
 
 
@@ -131,7 +130,6 @@
         allowClear: true
       });
 
-      // $('#adminGroup_users').select2('val',['2','3']);
     });
   </script>
 </div>

--- a/config/locales/cl.yml
+++ b/config/locales/cl.yml
@@ -309,6 +309,8 @@ cl:
         first_name: "Primer nombre"
         second_name: "Segundo nombre"
         last_name: "Apellido"
+      meeting:
+        minutes: "acta"
   unauthorized:
     manage:
       all: "No tienes acceso a esta area!"

--- a/db/migrate/20150211160349_change_type_to_minutes_in_meetings.rb
+++ b/db/migrate/20150211160349_change_type_to_minutes_in_meetings.rb
@@ -1,0 +1,9 @@
+class ChangeTypeToMinutesInMeetings < ActiveRecord::Migration
+  def up
+    change_column :meetings, :minutes, :text
+  end
+
+  def down
+    change_column :meetings, :minutes, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150113041434) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+ActiveRecord::Schema.define(version: 20150211160349) do
 
   create_table "admin_groups", force: true do |t|
     t.integer  "user_id"
@@ -23,7 +20,7 @@ ActiveRecord::Schema.define(version: 20150113041434) do
     t.datetime "updated_at"
   end
 
-  add_index "admin_groups", ["user_id", "group_id"], name: "index_admin_groups_on_user_id_and_group_id", unique: true, using: :btree
+  add_index "admin_groups", ["user_id", "group_id"], name: "index_admin_groups_on_user_id_and_group_id", unique: true
 
   create_table "groups", force: true do |t|
     t.string   "name"
@@ -41,7 +38,7 @@ ActiveRecord::Schema.define(version: 20150113041434) do
     t.datetime "updated_at"
   end
 
-  add_index "meeting_groups", ["meeting_id", "group_id"], name: "index_meeting_groups_on_meeting_id_and_group_id", unique: true, using: :btree
+  add_index "meeting_groups", ["meeting_id", "group_id"], name: "index_meeting_groups_on_meeting_id_and_group_id", unique: true
 
   create_table "meetings", force: true do |t|
     t.date     "date"
@@ -49,7 +46,7 @@ ActiveRecord::Schema.define(version: 20150113041434) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "state"
-    t.string   "minutes"
+    t.text     "minutes",    limit: 255
     t.string   "place"
     t.string   "title"
     t.datetime "start"
@@ -63,7 +60,7 @@ ActiveRecord::Schema.define(version: 20150113041434) do
     t.datetime "updated_at"
   end
 
-  add_index "member_groups", ["user_id", "group_id"], name: "index_member_groups_on_user_id_and_group_id", unique: true, using: :btree
+  add_index "member_groups", ["user_id", "group_id"], name: "index_member_groups_on_user_id_and_group_id", unique: true
 
   create_table "user_meetings", force: true do |t|
     t.integer  "user_id"
@@ -72,7 +69,7 @@ ActiveRecord::Schema.define(version: 20150113041434) do
     t.datetime "updated_at"
   end
 
-  add_index "user_meetings", ["user_id", "meeting_id"], name: "index_user_meetings_on_user_id_and_meeting_id", unique: true, using: :btree
+  add_index "user_meetings", ["user_id", "meeting_id"], name: "index_user_meetings_on_user_id_and_meeting_id", unique: true
 
   create_table "users", force: true do |t|
     t.string   "email"
@@ -90,7 +87,7 @@ ActiveRecord::Schema.define(version: 20150113041434) do
     t.datetime "reset_sent_at"
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["remember_token"], name: "index_users_on_remember_token", using: :btree
+  add_index "users", ["email"], name: "index_users_on_email", unique: true
+  add_index "users", ["remember_token"], name: "index_users_on_remember_token"
 
 end


### PR DESCRIPTION
- Added max length validation to 'minutes' attribute from the meeting table. 
- Change type to the same attribute from 'string' to 'text'.
- Resize box of the "acta" when an meeting will be updated.
